### PR TITLE
Fix startup errors and tidy utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Een simpele Discord muziekbot met `#` als prefix. Je kunt `#play`, `#skip`, `#pa
    ```bash
    pip install -r requirements.txt
    ```
-3. Start de bot met:
+3. Zet de nodige omgevingsvariabelen voor Discord en Spotify:
+   - `DISCORD_TOKEN` voor je bot-token.
+   - `SPOTIFY_CLIENT_ID` en `SPOTIFY_CLIENT_SECRET` voor Spotify (optioneel).
+4. Start de bot met:
    ```bash
    python3 musicbot.py
    ```

--- a/musicbot.py
+++ b/musicbot.py
@@ -184,4 +184,7 @@ async def on_ready():
     except Exception as e:
         print(f"Slash commands sync fout: {e}")
 
+if not TOKEN:
+    raise RuntimeError("DISCORD_TOKEN ontbreekt in de omgeving.")
+
 bot.run(TOKEN)

--- a/spotify_handler.py
+++ b/spotify_handler.py
@@ -11,10 +11,18 @@ SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 
 logger = logging.getLogger(__name__)
 
-sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(
-    client_id=SPOTIFY_CLIENT_ID,
-    client_secret=SPOTIFY_CLIENT_SECRET
-))
+if SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET:
+    sp = spotipy.Spotify(
+        auth_manager=SpotifyClientCredentials(
+            client_id=SPOTIFY_CLIENT_ID,
+            client_secret=SPOTIFY_CLIENT_SECRET,
+        )
+    )
+else:
+    logger.warning(
+        "SPOTIFY_CLIENT_ID/SECRET niet ingesteld. Spotify functionaliteit is uitgeschakeld."
+    )
+    sp = None
 
 def is_spotify_url(url):
     """Controleert of de URL een Spotify-link is."""
@@ -33,6 +41,10 @@ def get_spotify_tracks(url):
     Wordt gebruikt voor YouTube-zoekopdrachten.
     """
     results = []
+
+    if sp is None:
+        logger.warning("Spotify client niet beschikbaar. Sla request over.")
+        return results
 
     try:
         if 'track' in url:

--- a/utils/audio_utils.py
+++ b/utils/audio_utils.py
@@ -1,4 +1,3 @@
-import discord
 from discord import FFmpegPCMAudio
 
 FFMPEG_BEFORE_OPTS = '-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5'


### PR DESCRIPTION
## Summary
- remove unused `discord` import in `audio_utils`
- handle missing Spotify credentials gracefully
- document required environment variables
- add explicit check for missing `DISCORD_TOKEN`

## Testing
- `ruff check .`
- `python3 -m py_compile musicbot.py playlist_handler.py spotify_handler.py youtube_handler.py utils/*.py`
- `python3 musicbot.py` *(fails: `RuntimeError: DISCORD_TOKEN ontbreekt in de omgeving.`)*

------
https://chatgpt.com/codex/tasks/task_e_685014c6cc308327ba603844d272efc0